### PR TITLE
認証処理の盛り込み JWT生成まで

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@
 - [Doma Framework](https://github.com/domaframework/doma-spring-boot)
 - [ControllerからSwaggerを自動生成](https://qiita.com/rhirabay/items/f7527c91b5defc424b9c)
 - [SwaggerUIを簡単にGithub Pagesで公開する方法](https://qiita.com/youdays/items/38f15b90402d097fb13e)
+- [Spring Boot 認証・認可 REST API](https://b1san-blog.com/post/spring/spring-auth/)

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <spock.version>2.0-groovy-3.0</spock.version>
         <swagger.version>3.0.0</swagger.version>
         <logback.version>1.2.9</logback.version>
+        <jwt.version>0.11.2</jwt.version>
         <test.include.groovy>**/*.groovy</test.include.groovy>
     </properties>
 
@@ -147,6 +148,25 @@
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
             <version>2.4.4</version>
+        </dependency>
+
+        <!-- Json Web Token -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jwt.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <!-- Swagger SpringDoc -->

--- a/src/main/java/com/elite/miko/quiz/application/common/config/OpenApiConfig.java
+++ b/src/main/java/com/elite/miko/quiz/application/common/config/OpenApiConfig.java
@@ -157,7 +157,6 @@ public class OpenApiConfig {
             return new Content().addMediaType(MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                     new io.swagger.v3.oas.models.media.MediaType().schema(schema).example(example));
         } catch (Exception exception) {
-            exception.printStackTrace();
             throw new IllegalStateException("Swaggerのコンテンツ作成に失敗しました", exception);
         }
     }

--- a/src/main/java/com/elite/miko/quiz/application/common/config/OpenApiConfig.java
+++ b/src/main/java/com/elite/miko/quiz/application/common/config/OpenApiConfig.java
@@ -1,6 +1,7 @@
 package com.elite.miko.quiz.application.common.config;
 
 import com.elite.miko.quiz.application.common.constant.OpenApiConstant;
+import com.elite.miko.quiz.presentation.controller.QuizAuthorizationInterceptor;
 import com.elite.miko.quiz.presentation.model.response.ProblemResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.converter.ModelConverters;
@@ -9,7 +10,6 @@ import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponse;
-import java.math.BigDecimal;
 import org.springdoc.core.customizers.OpenApiCustomiser;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,8 +32,24 @@ public class OpenApiConfig {
     public OpenApiCustomiser openApiCustomiser(ObjectMapper objectMapper) {
         return openApi -> {
             addSchemas(openApi.getComponents());
+            addParameters(openApi.getComponents());
             addResponses(openApi.getComponents(), objectMapper);
         };
+    }
+
+    /**
+     * パラメータ定義を追加する
+     *
+     * @param components : コンポーネント
+     */
+    private void addParameters(Components components) {
+        components.addParameters(OpenApiConstant.AUTHORIZATION_HEADER, new Parameter()
+                .name(QuizAuthorizationInterceptor.X_QUIZ_AUTHORIZATION_HEADER)
+                .description("認証ヘッダー")
+                .in("header")
+                .style(Parameter.StyleEnum.SIMPLE)
+                .required(true)
+        );
     }
 
     /**
@@ -141,6 +157,7 @@ public class OpenApiConfig {
             return new Content().addMediaType(MediaType.APPLICATION_PROBLEM_JSON_VALUE,
                     new io.swagger.v3.oas.models.media.MediaType().schema(schema).example(example));
         } catch (Exception exception) {
+            exception.printStackTrace();
             throw new IllegalStateException("Swaggerのコンテンツ作成に失敗しました", exception);
         }
     }

--- a/src/main/java/com/elite/miko/quiz/application/common/config/TokenConfig.java
+++ b/src/main/java/com/elite/miko/quiz/application/common/config/TokenConfig.java
@@ -1,0 +1,15 @@
+package com.elite.miko.quiz.application.common.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 認証トークンのキー情報を持つConfig
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "extension.token")
+public class TokenConfig {
+    private String tokenKey;
+}

--- a/src/main/java/com/elite/miko/quiz/application/common/config/WebMvcConfig.java
+++ b/src/main/java/com/elite/miko/quiz/application/common/config/WebMvcConfig.java
@@ -1,6 +1,6 @@
 package com.elite.miko.quiz.application.common.config;
 
-import com.elite.miko.quiz.presentation.controller.QuizInterceptor;
+import com.elite.miko.quiz.presentation.controller.QuizAuthorizationInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
@@ -11,7 +11,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
 
-    private final QuizInterceptor quizInterceptor;
+    private final QuizAuthorizationInterceptor quizAuthorizationInterceptor;
 
     /**
      * Interceptorの追加を行う
@@ -20,6 +20,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
      */
     @Override
     public void addInterceptors(@NonNull InterceptorRegistry registry) {
-        registry.addInterceptor(quizInterceptor).addPathPatterns("**/miko/quiz/admin/*");
+        registry.addInterceptor(quizAuthorizationInterceptor).addPathPatterns("**/miko/quiz/admin/*");
     }
 }

--- a/src/main/java/com/elite/miko/quiz/application/common/constant/OpenApiConstant.java
+++ b/src/main/java/com/elite/miko/quiz/application/common/constant/OpenApiConstant.java
@@ -5,7 +5,7 @@ package com.elite.miko.quiz.application.common.constant;
  */
 public class OpenApiConstant {
 
-    public static final String QUIZ_ID = "quizId";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
 
     public static final String BAD_REQUEST = "badRequest";
     public static final String UNAUTHORIZED = "unauthorized";

--- a/src/main/java/com/elite/miko/quiz/application/common/utility/WebTokenUtil.java
+++ b/src/main/java/com/elite/miko/quiz/application/common/utility/WebTokenUtil.java
@@ -1,0 +1,84 @@
+package com.elite.miko.quiz.application.common.utility;
+
+import com.elite.miko.quiz.application.common.config.TokenConfig;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * WebTokenの生成 解析を行う共通クラス
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebTokenUtil {
+
+    private final TokenConfig tokenConfig;
+    private final Clock clock;
+
+    private static final int TOKEN_ENABLED_MINUTES = 30;
+
+    /**
+     * JsonWebTokenの生成を行い返却する
+     *
+     * @param id : トークンの生成に利用する管理者ID
+     * @return 生成したToken
+     */
+    public String generateToken(final String id) {
+
+        final String tokenKey = tokenConfig.getTokenKey();
+        if (Objects.isNull(tokenKey)) {
+            throw new IllegalStateException("Tokenのキー値が読み取れません");
+        }
+
+        // Tokenの有効期限を設定
+        // 現在日時 + TOKEN_ENABLED_MINUTES分の日時を指定
+        LocalDateTime tokenExpirationDateTime = LocalDateTime.now(clock).plusMinutes(TOKEN_ENABLED_MINUTES);
+        log.info("トークン有効期限 : {}", tokenExpirationDateTime);
+
+        return Jwts.builder()
+                .setSubject(id)
+                .setExpiration(this.toDate(tokenExpirationDateTime))
+                .signWith(Keys.hmacShaKeyFor(tokenKey.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+
+    /**
+     * Tokenの解析を行う
+     * @return PayloadのSubjectの値
+     */
+    public String analysisFromToken(final String token) {
+
+        final String tokenKey = tokenConfig.getTokenKey();
+        if (Objects.isNull(tokenKey)) {
+            throw new IllegalStateException("Tokenのキー値が読み取れません");
+        }
+        return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(tokenKey.getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    /**
+     * トークン有効期限のLocalDateTimeをDate型に変換する
+     *
+     * @param tokenExpirationDateTime : トークン有効期限を持つLocalDateTime
+     * @return 変換後のDate
+     */
+    private Date toDate(LocalDateTime tokenExpirationDateTime) {
+        ZonedDateTime zonedDateTime = ZonedDateTime.of(tokenExpirationDateTime, clock.getZone());
+        Instant instant = zonedDateTime.toInstant();
+        return Date.from(instant);
+    }
+}

--- a/src/main/java/com/elite/miko/quiz/application/service/AdminAccountServiceImpl.java
+++ b/src/main/java/com/elite/miko/quiz/application/service/AdminAccountServiceImpl.java
@@ -1,18 +1,22 @@
 package com.elite.miko.quiz.application.service;
 
 import com.elite.miko.quiz.application.common.utility.HashUtil;
+import com.elite.miko.quiz.application.common.utility.WebTokenUtil;
 import com.elite.miko.quiz.application.exception.LoginFailureException;
 import com.elite.miko.quiz.domain.repository.AdminAccountRepository;
 import com.elite.miko.quiz.domain.service.AdminAccountService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AdminAccountServiceImpl implements AdminAccountService {
 
     private final AdminAccountRepository adminAccountRepository;
     private final HashUtil hashUtil;
+    private final WebTokenUtil webTokenUtil;
 
     /**
      * IDとパスワードの組み合わせに対する認証処理を行う
@@ -23,6 +27,7 @@ public class AdminAccountServiceImpl implements AdminAccountService {
      */
     @Override
     public String login(String accountId, String password) {
+
         // パスワードをsha256でハッシュ化する
         final String hashedPassword = hashUtil.createSha256Password(password);
         final boolean isLogin = adminAccountRepository.login(accountId, hashedPassword);
@@ -30,7 +35,7 @@ public class AdminAccountServiceImpl implements AdminAccountService {
             throw new LoginFailureException("ログインに失敗しました");
         }
 
-        // TODO 認証処理盛り込み時にJWTでトークンを生成して返却するように処理を盛り込む
-        return "token";
+        // 認証に成功した場合はJson Web Token を生成
+        return webTokenUtil.generateToken(accountId);
     }
 }

--- a/src/main/java/com/elite/miko/quiz/presentation/controller/LoginController.java
+++ b/src/main/java/com/elite/miko/quiz/presentation/controller/LoginController.java
@@ -50,7 +50,7 @@ public class LoginController {
 
         // 生成したTokenをAuthorizationヘッダーに詰めて返却
         HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.set(QuizAuthorizationInterceptor.AUTHORIZATION_HEADER, jsonWebToken);
+        responseHeaders.set(QuizAuthorizationInterceptor.X_QUIZ_AUTHORIZATION_HEADER, jsonWebToken);
         responseHeaders.setContentType(MediaType.APPLICATION_JSON);
         return ResponseEntity.ok().headers(responseHeaders).build();
     }

--- a/src/main/java/com/elite/miko/quiz/presentation/controller/LoginController.java
+++ b/src/main/java/com/elite/miko/quiz/presentation/controller/LoginController.java
@@ -10,7 +10,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,8 +45,13 @@ public class LoginController {
             @ApiResponse(responseCode = "500", ref = OpenApiConstant.INTERNAL_SERVER_ERROR),
     })
     public ResponseEntity<?> isLogin(@Validated @RequestBody LoginForm loginForm) {
-        final String token = adminAccountService.login(loginForm.getAccountId(), loginForm.getPassword());
-        // TODO 認証処理盛り込み時にJWTでトークンを生成して返却するように処理を盛り込む
-        return new ResponseEntity<>(token, HttpStatus.OK);
+
+        final String jsonWebToken = adminAccountService.login(loginForm.getAccountId(), loginForm.getPassword());
+
+        // 生成したTokenをAuthorizationヘッダーに詰めて返却
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set(QuizAuthorizationInterceptor.AUTHORIZATION_HEADER, jsonWebToken);
+        responseHeaders.setContentType(MediaType.APPLICATION_JSON);
+        return ResponseEntity.ok().headers(responseHeaders).build();
     }
 }

--- a/src/main/java/com/elite/miko/quiz/presentation/controller/QuizAdminController.java
+++ b/src/main/java/com/elite/miko/quiz/presentation/controller/QuizAdminController.java
@@ -63,6 +63,10 @@ public class QuizAdminController {
     @GetMapping(path = "/quizzes")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "クイズの一覧を取得する(管理用)")
+    @Parameters({
+            @Parameter(name = QuizAuthorizationInterceptor.X_QUIZ_AUTHORIZATION_HEADER,
+                    ref = OpenApiConstant.AUTHORIZATION_HEADER)
+    })
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -93,6 +97,10 @@ public class QuizAdminController {
     @GetMapping(path = "/quizzes/requests")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "リクエスト中のクイズ一覧を取得する")
+    @Parameters({
+            @Parameter(name = QuizAuthorizationInterceptor.X_QUIZ_AUTHORIZATION_HEADER,
+                    ref = OpenApiConstant.AUTHORIZATION_HEADER)
+    })
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -122,6 +130,10 @@ public class QuizAdminController {
     @PostMapping(path = "/quizzes")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "クイズの追加を行う")
+    @Parameters({
+            @Parameter(name = QuizAuthorizationInterceptor.X_QUIZ_AUTHORIZATION_HEADER,
+                    ref = OpenApiConstant.AUTHORIZATION_HEADER)
+    })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
             content = @Content(schema = @Schema(implementation = QuizAddForm.class))
     )
@@ -147,6 +159,10 @@ public class QuizAdminController {
     @PutMapping(path = "/quizzes")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "クイズの更新を行う")
+    @Parameters({
+            @Parameter(name = QuizAuthorizationInterceptor.X_QUIZ_AUTHORIZATION_HEADER,
+                    ref = OpenApiConstant.AUTHORIZATION_HEADER)
+    })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(
             content = @Content(schema = @Schema(implementation = QuizUpdateForm.class))
     )
@@ -177,7 +193,9 @@ public class QuizAdminController {
             @Parameter(name = "quizIdList", in = ParameterIn.QUERY,
                     description = "削除対象のクイズIDリストカンマ区切りで設定する 最大50件",
                     schema = @Schema(type = "array", format = "int64")
-            )
+            ),
+            @Parameter(name = QuizAuthorizationInterceptor.X_QUIZ_AUTHORIZATION_HEADER,
+                    ref = OpenApiConstant.AUTHORIZATION_HEADER)
     })
     @ApiResponses({
             @ApiResponse(responseCode = "204", ref = OpenApiConstant.DELETED_SUCCESS),

--- a/src/main/java/com/elite/miko/quiz/presentation/controller/QuizAuthorizationInterceptor.java
+++ b/src/main/java/com/elite/miko/quiz/presentation/controller/QuizAuthorizationInterceptor.java
@@ -13,7 +13,9 @@ import org.springframework.web.servlet.HandlerInterceptor;
  */
 @Slf4j
 @Component
-public class QuizInterceptor implements HandlerInterceptor {
+public class QuizAuthorizationInterceptor implements HandlerInterceptor {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
 
     /**
      * Controllerの事前処理を行う

--- a/src/main/java/com/elite/miko/quiz/presentation/controller/QuizAuthorizationInterceptor.java
+++ b/src/main/java/com/elite/miko/quiz/presentation/controller/QuizAuthorizationInterceptor.java
@@ -15,7 +15,7 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 public class QuizAuthorizationInterceptor implements HandlerInterceptor {
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String X_QUIZ_AUTHORIZATION_HEADER = "X-quiz-authorization-header";
 
     /**
      * Controllerの事前処理を行う

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,4 +17,6 @@ logging:
 extension:
   hash:
     salt: salt
+  token:
+    tokenKey: tokenKey
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,5 +18,5 @@ extension:
   hash:
     salt: salt
   token:
-    tokenKey: tokenKey
+    tokenKey: op5hhr4ysc7ymbxi7mixp604qp9fu651szr4n24wkc9x3ng26xccd1f1xz8ltokenkey
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -33,3 +33,5 @@ doma:
 extension:
   hash:
     salt: salt
+  token:
+    tokenKey: tokenKey

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,4 +34,4 @@ extension:
   hash:
     salt: salt
   token:
-    tokenKey: tokenKey
+    tokenKey: op5hhr4ysc7ymbxi7mixp604qp9fu651szr4n24wkc9x3ng26xccd1f1xz8ltokenkey

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,10 +26,13 @@ management:
         http:
           server.requests: 0.5, 0.95, 0.99
 
-# パスワードハッシュ化の際に使用する文字列
 extension:
   hash:
+    # パスワードハッシュ化の際に使用する文字列
     salt: ${salt}
+  token:
+    # JsonWebTokenのキーに使用する値
+    tokenKey: ${tokenKey}
 
 ---
 # -Dspring.profiles.activeを指定しなかった場合に実行される application.ymlの指定


### PR DESCRIPTION
- 出来たところ
    - ログイン成功時に自作の認証ヘッダーにJsonWebトークンを付与して返す
    - Swaggerの入力欄に自作認証ヘッダーの設定欄を追加
- 調査中
    - 受領したトークンに対してどうやって認証するか 